### PR TITLE
Update image and text alignment

### DIFF
--- a/css/jeopardy.css
+++ b/css/jeopardy.css
@@ -87,6 +87,12 @@ body {
 	color: white;
 }
 
+#question-image {
+    height:100%;
+    flex: 1;
+    overflow-y: auto;
+}
+
 #daily-double-modal .modal-footer {
 	text-align: center;
 }
@@ -136,6 +142,9 @@ body {
 #question-modal-body {
 	margin-left: 10%;
 	margin-right: 10%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 
 #game-load-logo-img {


### PR DESCRIPTION
Now When you add images, if they aren't the right size, they'll still fit correctly in the div and be automatically resized without any strange overflow. Also, question text remains centered if there is not an image