### PR TITLE
Fix occasional $NaN scores after final wager

### DIFF
--- a/js/jeopardy.js
+++ b/js/jeopardy.js
@@ -466,7 +466,7 @@ function handleFinalAnswer(){
         var buttonAction = buttonID.substr(9,5);
         var playerNumber = buttonID.charAt(7);
         var wagerID = '#wager-player-' + playerNumber + '-input';
-        var wager = $(wagerID).val() == '' ? 0 : parseInt($(wagerID).val());
+        var wager = $(wagerID).val() == '' ? 0 :  parseInt($(wagerID).val().replace(/[^0-9\.]/, ''));
         var scoreVariable = 'score_player_' + playerNumber;
         var otherButtonID = '#final-p' + playerNumber + '-' +
             (buttonAction === 'right' ? 'wrong' : 'right') + '-button';


### PR DESCRIPTION
If a player enters a wager starting with a $, they lose ALL their money!! This stops that by discarding letters and symbols in the final wager that aren't a period.

Tested real quick by overriding this line on my own server and it seems to work as I intended.